### PR TITLE
Allow customization of the authentication provider

### DIFF
--- a/DependencyInjection/Security/Factory/GetJWTFactory.php
+++ b/DependencyInjection/Security/Factory/GetJWTFactory.php
@@ -15,9 +15,9 @@ class GetJWTFactory implements SecurityFactoryInterface
      */
     public function create(ContainerBuilder $container, $id, $config, $userProvider, $defaultEntryPoint)
     {
-        $providerId = 'security.authentication.provider.dao.'.$id;
+        $providerId = 'security.authentication.provider.get.jwt.'.$id;
         $container
-            ->setDefinition($providerId, new DefinitionDecorator('security.authentication.provider.dao'))
+            ->setDefinition($providerId, new DefinitionDecorator($config['authentication_provider']))
             ->replaceArgument(0, new Reference($userProvider))
             ->replaceArgument(2, $id)
         ;
@@ -83,6 +83,9 @@ class GetJWTFactory implements SecurityFactoryInterface
                 ->end()
                 ->booleanNode('throw_exceptions')
                     ->defaultFalse()
+                ->end()
+                ->scalarNode('authentication_provider')
+                    ->defaultValue('security.authentication.provider.dao')
                 ->end()
             ->end();
     }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Usage
                 username_parameter: username
                 password_parameter: password
                 post_only: true
+                authentication_provider: security.authentication.provider.dao
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
 


### PR DESCRIPTION
I ran into an issue at work where I can't use the default SecurityBundle authentication provider, because I have to call an external service with the password to have it validated (à la LDAP). This allows me to provide a custom authentication provider where I can check the credentials however I want.