### PR TITLE
Bump LexikJWTAuthenticationBundle version to 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.3",
         "symfony/symfony": "~2.3",
         "symfony/framework-bundle": "~2.3",
-        "lexik/jwt-authentication-bundle": "~1.0"
+        "lexik/jwt-authentication-bundle": "~1.2"
     },
     "autoload": {
         "psr-0": { "Gfreeau\\Bundle\\GetJWTBundle": "" }
@@ -27,4 +27,3 @@
         }
     }
 }
-


### PR DESCRIPTION
Update LexikJWTAuthenticationBundle dependency version to 1.2 to include cookie extractor support and other latest features.