### PR TITLE
Sf4 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/DependencyInjection/Security/Factory/GetJWTFactory.php
+++ b/DependencyInjection/Security/Factory/GetJWTFactory.php
@@ -3,10 +3,12 @@
 namespace Gfreeau\Bundle\GetJWTBundle\DependencyInjection\Security\Factory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
+
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 
 class GetJWTFactory implements SecurityFactoryInterface
 {
@@ -17,7 +19,7 @@ class GetJWTFactory implements SecurityFactoryInterface
     {
         $providerId = 'security.authentication.provider.get.jwt.'.$id;
         $container
-            ->setDefinition($providerId, new DefinitionDecorator($config['authentication_provider']))
+            ->setDefinition($providerId, $this->createChildDefinition($config['authentication_provider']))
             ->replaceArgument(0, new Reference($userProvider))
             ->replaceArgument(1, new Reference($config['user_checker']))
             ->replaceArgument(2, $id)
@@ -25,7 +27,7 @@ class GetJWTFactory implements SecurityFactoryInterface
 
         $listenerId = 'security.authentication.listener.get.jwt.'.$id;
         $listener = $container
-            ->setDefinition($listenerId, new DefinitionDecorator('gfreeau_get_jwt.security.authentication.listener'))
+            ->setDefinition($listenerId, $this->createChildDefinition('gfreeau_get_jwt.security.authentication.listener'))
             ->replaceArgument(2, $id)
             ->replaceArgument(5, $config)
         ;
@@ -93,4 +95,12 @@ class GetJWTFactory implements SecurityFactoryInterface
             ->end();
     }
 
+    private function createChildDefinition($parent)
+    {
+        if (class_exists('Symfony\Component\DependencyInjection\ChildDefinition')) {
+            return new ChildDefinition($parent);
+        }
+
+        return new DefinitionDecorator($parent);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,10 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "^2.7 || ^3.2 || ^4.0",
+        "symfony/http-kernel": "^2.7 || ^3.2 || ^4.0",
+        "symfony/dependency-injection": "^2.7 || ^3.2 || ^4.0",
         "symfony/security-bundle": "^2.7 || ^3.2 || ^4.0",
-        "lexik/jwt-authentication-bundle": "^1.4.3|^2.0.0@dev"
+        "lexik/jwt-authentication-bundle": "^1.4.3 || ^2.0.0"
     },
     "autoload": {
         "psr-0": { "Gfreeau\\Bundle\\GetJWTBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
         "php": ">=5.3.3",
         "symfony/http-kernel": "^2.7 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.7 || ^3.2 || ^4.0",
-        "symfony/security-bundle": "^2.7 || ^3.2 || ^4.0",
+        "symfony/security-bundle": "^2.7 || ^3.2 || ^4.0"
+    },
+    "suggests": {
         "lexik/jwt-authentication-bundle": "^1.4.3 || ^2.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "^2.3 || ^3.3 || ^4.0",
-        "symfony/security-bundle": "^2.3 || ^3.3 || ^4.0",
+        "symfony/framework-bundle": "^2.7 || ^3.2 || ^4.0",
+        "symfony/security-bundle": "^2.7 || ^3.2 || ^4.0",
         "lexik/jwt-authentication-bundle": "^1.4.3|^2.0.0@dev"
     },
     "autoload": {


### PR DESCRIPTION
This bundle is not really compatible Symfony4 (because of the class `DefinitionDecorator` is now gone, we have to use `ChildDefinition` instead), I did as lexik's bundle did to be able to use both.

I also removed the hard dependency on the lexik's bundle, as nothing was really tying it to the bundle, except the handlers part, which can be something else instead. So I put it in the suggestions.

I also removed the dependency towards the framework-bundle, as the real dependencies were towards the http-kernel and dependency-injection.