### PR TITLE
Updating symfony constraints to only ^4 || ^5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.3.3",
-        "symfony/http-kernel": "^2.7 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.7 || ^3.2 || ^4.0",
-        "symfony/security-bundle": "^2.7 || ^3.2 || ^4.0"
+        "symfony/http-kernel": "^4.0 || ^5.0",
+        "symfony/dependency-injection": "^4.0 || ^5.0",
+        "symfony/security-bundle": "^4.0 || ^5.0"
     },
     "suggests": {
         "lexik/jwt-authentication-bundle": "^1.4.3 || ^2.0.0"


### PR DESCRIPTION
Removed PHP constraint, as this is handled by SF anyways